### PR TITLE
Updated explicitness ratings based on Danbooru changes

### DIFF
--- a/boorufetch.go
+++ b/boorufetch.go
@@ -27,21 +27,22 @@ const (
 type Rating uint8
 
 const (
-	Safe Rating = iota
+	General Rating = iota
+	Sensitive
 	Questionable
 	Explicit
 )
 
 var (
-	ratingRunes   = [...]byte{'s', 'q', 'e'}
-	ratingStrings = [...]string{"safe", "questionable", "explicit"}
+	ratingRunes   = [...]byte{'g', 's', 'q', 'e'}
+	ratingStrings = [...]string{"general", "sensitive", "questionable", "explicit"}
 )
 
 func (r *Rating) UnmarshalJSON(buf []byte) error {
 	if len(buf) < 3 {
 		return ErrUnknownRating(buf)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if buf[1] == ratingRunes[i] {
 			*r = Rating(i)
 			return nil

--- a/boorufetch.go
+++ b/boorufetch.go
@@ -28,14 +28,14 @@ type Rating uint8
 
 const (
 	General Rating = iota
-	Sensitive
 	Questionable
 	Explicit
+	Sensitive
 )
 
 var (
-	ratingRunes   = [...]byte{'g', 's', 'q', 'e'}
-	ratingStrings = [...]string{"general", "sensitive", "questionable", "explicit"}
+	ratingRunes   = [...]byte{'g', 'q', 'e', 's'}
+	ratingStrings = [...]string{"general", "questionable", "explicit", "sensitive"}
 )
 
 func (r *Rating) UnmarshalJSON(buf []byte) error {


### PR DESCRIPTION
Captchouli is currently broken due to Danbooru changing its explicitness ratings. Boorufetch does not recognize the "General" rating and will cause Captchouli to throw `error initializing image pool for tag 'patchouli_knowledge': unknown rating: "g"`. 